### PR TITLE
auto accept all android sdk licences

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ build:
   script:
     - npm install
     - mkdir www
+    - yes | /opt/android-sdk/tools/bin/sdkmanager --licenses || true
     - ionic cordova build android
   artifacts:
     paths:


### PR DESCRIPTION
`yes` is piped to `sdkmanager --licences` but the command returns a non-zero exit code 🤦‍♂️ so the `||` defaults to `true` as the result of the overall command hence the job keeps going

see https://unix.stackexchange.com/questions/190543/what-does-mean-in-bash